### PR TITLE
fix: テンプレート記法をJQクエリ形式に統一

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ PostToolUse:
         value: ".go"
     actions:
       - type: command
-        command: "gofmt -w {tool_input.file_path}"
+        command: "gofmt -w {.tool_input.file_path}"
       - type: output
-        message: "Formatted {tool_input.file_path}"
+        message: "Formatted {.tool_input.file_path}"
 
 PreToolUse:
   - matcher: "Bash"
@@ -247,7 +247,7 @@ PostToolUse:
         value: ".go"
     actions:
       - type: command
-        command: "gofmt -w {tool_input.file_path}"
+        command: "gofmt -w {.tool_input.file_path}"
 ```
 
 Block git add (recommended approach):

--- a/config.yaml
+++ b/config.yaml
@@ -5,7 +5,7 @@ PostToolUse:
         value: ".go"
     actions:
       - type: command
-        command: "gofmt -w {tool_input.file_path}"
+        command: "gofmt -w {.tool_input.file_path}"
 
 PreToolUse:
   - matcher: "Bash"


### PR DESCRIPTION
## 何をやったか

テンプレート記法の統一を行いました。`{tool_input.file_path}` を `{.tool_input.file_path}` に修正しています。

## 修正が必要になった背景

実装では `unifiedTemplateReplace` 関数がJQクエリとして `{}` 内を解析するため、`.` で始まるJQクエリ形式が正しい記法です。しかし、ドキュメントや設定例では古い記法 `{tool_input.file_path}` が残っていたため、実装と一致するように修正しました。

## 変更内容

- **README.md**: ドキュメント内のサンプルコードのテンプレート記法を修正
- **config.yaml**: 設定ファイルのテンプレート記法を修正

これにより、ユーザーがドキュメントや設定例をコピーした際に正しく動作するようになります。