### PR TITLE
docs: README.mdの修正とCLAUDE.mdの追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,120 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+cchook is a CLI tool that simplifies Claude Code hook configuration by providing YAML-based configuration and template syntax instead of complex JSON one-liners. It processes JSON input from Claude Code hooks via stdin and executes configured actions based on matching conditions.
+
+## Development Commands
+
+```bash
+# Build the project
+go build -o cchook
+
+# Run all tests
+go test ./...
+
+# Run specific test file
+go test -v ./hooks_test.go
+
+# Run with coverage
+go test -cover ./...
+
+# Install locally for testing
+go install
+
+# Lint code (via pre-commit)
+pre-commit run --all-files
+
+# Test the tool manually (requires JSON input via stdin)
+echo '{"session_id":"test","hook_event_name":"PreToolUse","tool_name":"Write","tool_input":{"file_path":"test.go"}}' | ./cchook -event PreToolUse
+```
+
+## Architecture
+
+### Core Components
+
+The application follows a modular architecture with clear separation of concerns:
+
+**Main Entry Point** (`main.go`)
+- CLI argument parsing (`-config`, `-command`, `-event`)
+- Delegates to appropriate hook execution functions
+- Handles ExitError for proper exit codes and output routing
+
+**Type System** (`types.go`)
+- Defines all event types: PreToolUse, PostToolUse, Stop, SubagentStop, Notification, PreCompact
+- Event-specific input structures with embedded BaseInput
+- Hook and Action interfaces for polymorphic behavior
+- Separate condition and action types for each event
+
+**Configuration** (`config.go`)
+- YAML configuration loading with XDG_CONFIG_HOME support
+- Default path: `~/.config/cchook/config.yaml`
+- Custom path via `-config` flag
+
+**Input Processing** (`parser.go`)
+- Generic parsing function with type constraints
+- Tool-specific parsing for PreToolUse/PostToolUse (complex tool_input handling)
+- Returns both structured data and raw JSON for template processing
+
+**Hook Execution** (`hooks.go`)
+- Event-specific hook execution functions
+- Matcher checking (partial string matching with pipe separation)
+- Condition evaluation per event type
+- Dry-run mode for debugging configurations
+
+**Action Execution** (`actions.go`)
+- Command execution via shell
+- Output handling with exit status control
+- ExitError creation for blocking execution (PreToolUse only)
+
+**Template Engine** (`template_jq.go`)
+- Unified `{.field}` syntax for JSON field access
+- Full jq query support within template braces
+- Query caching for performance
+- Error handling with `[JQ_ERROR: ...]` format
+
+**Utilities** (`utils.go`)
+- Condition checking functions per event type
+- Command execution wrapper
+- File existence, extension, and URL pattern matching
+
+### Data Flow
+
+1. **Input**: JSON from Claude Code hooks via stdin
+2. **Parsing**: Event-specific parsing with tool input handling
+3. **Hook Matching**: Matcher patterns (partial string matching) and conditions
+4. **Template Processing**: jq-based field substitution in commands/messages
+5. **Action Execution**: Shell commands or output with exit status control
+6. **Exit Handling**: ExitError for blocking vs allowing execution
+
+### Key Design Patterns
+
+**Event-Driven Architecture**: Each Claude Code event type has dedicated input/hook/action structures
+
+**Template System**: Consistent `{.field}` syntax across all actions, powered by gojq for complex queries
+
+**Condition System**: Event-specific condition types with common patterns (file_extension, command_contains, etc.)
+
+**Error Handling**: Custom ExitError type for precise control over exit codes and stderr/stdout routing
+
+**Caching**: JQ query compilation caching for performance optimization
+
+## Testing Strategy
+
+Tests are organized by component with comprehensive coverage:
+- Unit tests for each module (*_test.go files)
+- Integration tests for hook execution flows
+- Template processing tests with real-world examples
+- Dry-run functionality testing
+- Error condition coverage
+
+## Configuration Format
+
+The tool uses YAML configuration with event-specific hook definitions. Each hook contains:
+- `matcher`: Tool name pattern matching (partial, pipe-separated)
+- `conditions`: Event-specific condition checks
+- `actions`: Command execution or output with optional exit_status
+
+Template variables are available based on the event type and include fields from BaseInput, tool-specific data, and full jq query support.

--- a/README.md
+++ b/README.md
@@ -107,9 +107,8 @@ Create `~/.config/cchook/config.yaml` with your desired hooks:
 ```yaml
 # Auto-format Go files after Write/Edit
 PostToolUse:
-  - conditions:
-      - type: tool_name
-        value: "Write|Edit"
+  - matcher: "Write|Edit"
+    conditions:
       - type: file_extension
         value: ".go"
     actions:
@@ -118,17 +117,15 @@ PostToolUse:
 
 # Guide users to use better alternatives
 PreToolUse:
-  - conditions:
-      - type: tool_name
-        value: "Bash"
+  - matcher: "Bash"
+    conditions:
       - type: command_starts_with
         value: "python"
     actions:
       - type: output
         message: "pythonは使わず`uv`を代わりに使いましょう"
-  - conditions:
-      - type: tool_name
-        value: "WebFetch"
+  - matcher: "WebFetch"
+    conditions:
       - type: url_starts_with
         value: "https://github.com"
     actions:
@@ -144,18 +141,16 @@ Auto-format different file types:
 
 ```yaml
 PostToolUse:
-  - conditions:
-      - type: tool_name
-        value: "Write|Edit"
+  - matcher: "Write|Edit"
+    conditions:
       - type: file_extension
         value: ".go"
     actions:
       - type: command
         command: "gofmt -w {.tool_input.file_path}"
 
-  - conditions:
-      - type: tool_name
-        value: "Write|Edit"
+  - matcher: "Write|Edit"
+    conditions:
       - type: file_extension
         value: ".py"
     actions:
@@ -167,9 +162,8 @@ Run pre-commit hooks automatically:
 
 ```yaml
 PostToolUse:
-  - conditions:
-      - type: tool_name
-        value: "Write|Edit|MultiEdit"
+  - matcher: "Write|Edit|MultiEdit"
+    conditions:
       - type: file_exists
         value: ".pre-commit-config.yaml"
     actions:
@@ -183,9 +177,8 @@ Block dangerous commands:
 
 ```yaml
 PreToolUse:
-  - conditions:
-      - type: tool_name
-        value: "Bash"
+  - matcher: "Bash"
+    conditions:
       - type: command_starts_with
         value: "rm -rf"
     actions:
@@ -200,9 +193,8 @@ Track external API usage:
 
 ```yaml
 PreToolUse:
-  - conditions:
-      - type: tool_name
-        value: "WebFetch"
+  - matcher: "WebFetch"
+    conditions:
       - type: url_starts_with
         value: "https://api."
     actions:
@@ -300,9 +292,8 @@ YAML Multi-line Support:
 
 ```yaml
 PostToolUse:
-  - conditions:
-      - type: tool_name
-        value: "Write|Edit"
+  - matcher: "Write|Edit"
+    conditions:
       - type: file_extension
         value: ".py"
       - type: file_exists
@@ -318,9 +309,8 @@ PostToolUse:
 
 ```yaml
 PostToolUse:
-  - conditions:
-      - type: tool_name
-        value: "Write|Edit"
+  - matcher: "Write|Edit"
+    conditions:
       - type: file_extension
         value: ".go"
     actions:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,48 @@ PreToolUse:
         message: "WebFetchではなく、`gh`コマンド経由で情報を取得しましょう"
 ```
 
+## CLI Options
+
+### Configuration File Path
+
+By default, cchook looks for configuration files in the following order:
+
+1. Path specified by `-config` flag
+2. `$XDG_CONFIG_HOME/cchook/config.yaml` (if `XDG_CONFIG_HOME` is set)
+3. `~/.config/cchook/config.yaml` (default fallback)
+
+#### Using Custom Configuration File
+
+You can specify a custom configuration file path using the `-config` flag:
+
+```bash
+# Use custom config file
+cchook -config /path/to/my-config.yaml -event PreToolUse
+
+# Example: Development vs Production configs
+cchook -config ~/.config/cchook/dev-config.yaml -event PostToolUse
+cchook -config ~/.config/cchook/prod-config.yaml -event Stop
+```
+
+#### Example Claude Code Hook with Custom Config
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cchook -config ~/.config/cchook/dev-config.yaml -event PreToolUse"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
 ## Configuration Examples
 
 ### File Processing

--- a/README.md
+++ b/README.md
@@ -236,10 +236,15 @@ Stop:
 - `PreCompact`
   - Before conversation compaction
 
+### Matcher
+
+- `matcher`
+  - Match tool name using pipe-separated patterns (e.g., "Write|Edit", "Bash", "WebFetch")
+  - Empty matcher matches all tools
+  - Uses the same syntax as Claude Code's built-in hook matcher field
+
 ### Conditions
 
-- `tool_name`
-  - Match tool name (e.g., "Write|Edit", "Bash", "WebFetch")
 - `file_extension`
   - Match file extension in `tool_input.file_path`
 - `command_contains`


### PR DESCRIPTION
## 修正内容

### README.mdの修正
- **設定例の修正**: `type: tool_name`を`matcher`フィールドに移動し、実装との一貫性を改善
- **Matcherセクションの追加**: Configuration Referenceに新しいMatcherセクションを追加し、Claude Codeとの互換性を明記
- **CLI Optionsセクションの追加**: `-config`フラグの詳細説明とXDG_CONFIG_HOME対応を記載
- **Conditionsセクションの整理**: 重複したtool_nameタイプを削除

### CLAUDE.mdの追加
- Claude Code向けプロジェクトドキュメントを新規作成
- 開発コマンド、アーキテクチャ、データフロー、設計パターンを詳細記載
- 8つのコアコンポーネントの説明を含む包括的なドキュメント

## 修正が必要になった背景

### 実装とドキュメントの乖離発見
README.mdと実際の実装コードを詳細に比較した結果、以下の重大な乖離を発見：

1. **マッチャーとコンディションの混同**: README.mdでは`type: tool_name`として条件に書かれているものが、実際の実装では`matcher`フィールドに書くべきもの
2. **CLIオプションの記載不足**: `-config`フラグという重要機能が完全に未記載
3. **条件タイプの誤記**: `tool_name`という条件タイプは実装に存在しない

### ユーザビリティへの深刻な影響
- ユーザーが設定例をそのまま使用すると動作しない
- 重要な機能（カスタム設定ファイルパス指定）を利用できない
- 実装には高度な機能（XDG_CONFIG_HOME対応、JQキャッシュ等）があるのにドキュメント化されていない

## 解決アプローチ

semantic commitを使用して意味のある単位で修正を実施：

1. **fix**: 設定例でマッチャーとコンディションの分離 
2. **docs**: Matcherセクションの追加とConditionsの整理
3. **docs**: CLI -configフラグのドキュメント追加
4. **docs**: Claude Code向けプロジェクトドキュメント追加

これにより、ユーザーが実際に動作する設定を書けるようになり、全ての機能を適切に活用できるようになりました。