### PR TITLE
feat: SessionStartイベントに条件チェック機能を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,11 +303,31 @@ Initialize session with custom setup:
 
 ```yaml
 SessionStart:
-  - actions:
+  - matcher: "startup"
+    actions:
       - type: command
         command: "echo 'Session {.session_id} started at $(date)' >> ~/claude-sessions.log"
       - type: output
         message: "🚀 Claude Code session initialized"
+        exit_status: 0
+
+  # Project-specific initialization
+  - matcher: "startup"
+    conditions:
+      - type: file_exists
+        value: "go.mod"
+    actions:
+      - type: output
+        message: "Go project detected - remember to run tests"
+        exit_status: 0
+
+  - matcher: "startup"
+    conditions:
+      - type: file_exists_recursive
+        value: "pyproject.toml"
+    actions:
+      - type: output
+        message: "Python project detected - using uv for package management"
         exit_status: 0
 ```
 
@@ -352,7 +372,7 @@ UserPromptSubmit:
   - Before conversation compaction
 - `SessionStart`
   - When Claude Code session starts
-  - No conditions available (actions only)
+  - Supports conditions like `file_exists` and `file_exists_recursive`
 - `UserPromptSubmit`
   - When user submits a prompt
 
@@ -390,6 +410,12 @@ UserPromptSubmit:
   - Check if specified file exists
 - `url_starts_with`
   - Match URL prefix (WebFetch tool)
+
+#### SessionStart
+- `file_exists`
+  - Check if specified file exists
+- `file_exists_recursive`
+  - Check if file exists recursively in directory tree
 
 #### UserPromptSubmit
 - `prompt_contains`

--- a/hooks.go
+++ b/hooks.go
@@ -294,6 +294,19 @@ func dryRunSessionStartHooks(config *Config, input *SessionStartInput, rawJSON i
 		if hook.Matcher != "" && hook.Matcher != input.Source {
 			continue
 		}
+		
+		// 条件チェック
+		shouldExecute := true
+		for _, condition := range hook.Conditions {
+			if !checkSessionStartCondition(condition, input) {
+				shouldExecute = false
+				break
+			}
+		}
+		if !shouldExecute {
+			continue
+		}
+		
 		executed = true
 		fmt.Printf("[Hook %d] Matcher: %s, Source: %s\n", i+1, hook.Matcher, input.Source)
 		for _, action := range hook.Actions {
@@ -428,6 +441,19 @@ func executeSessionStartHooks(config *Config, input *SessionStartInput, rawJSON 
 		if hook.Matcher != "" && hook.Matcher != input.Source {
 			continue
 		}
+		
+		// 条件チェック
+		shouldExecute := true
+		for _, condition := range hook.Conditions {
+			if !checkSessionStartCondition(condition, input) {
+				shouldExecute = false
+				break
+			}
+		}
+		if !shouldExecute {
+			continue
+		}
+		
 		for _, action := range hook.Actions {
 			if err := executeSessionStartAction(action, input, rawJSON); err != nil {
 				fmt.Fprintf(os.Stderr, "SessionStart hook %d failed: %v\n", i, err)

--- a/types.go
+++ b/types.go
@@ -184,8 +184,9 @@ type PreCompactHook struct {
 }
 
 type SessionStartHook struct {
-	Matcher string               `yaml:"matcher"` // "startup", "resume", or "clear"
-	Actions []SessionStartAction `yaml:"actions"`
+	Matcher    string                  `yaml:"matcher"` // "startup", "resume", or "clear"
+	Conditions []SessionStartCondition `yaml:"conditions,omitempty"`
+	Actions    []SessionStartAction    `yaml:"actions"`
 }
 
 type UserPromptSubmitHook struct {
@@ -205,6 +206,11 @@ type PostToolUseCondition struct {
 }
 
 type UserPromptSubmitCondition struct {
+	Type  string `yaml:"type"`
+	Value string `yaml:"value"`
+}
+
+type SessionStartCondition struct {
 	Type  string `yaml:"type"`
 	Value string `yaml:"value"`
 }

--- a/utils.go
+++ b/utils.go
@@ -83,21 +83,7 @@ func checkPreToolUseCondition(condition PreToolUseCondition, input *PreToolUseIn
 		}
 	case "file_exists_recursive":
 		// ファイルが再帰的に存在するか
-		found := false
-		err := filepath.Walk(".", func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return nil // エラーがあっても続ける
-			}
-			if !info.IsDir() && filepath.Base(path) == condition.Value {
-				found = true
-				return filepath.SkipAll // 見つかったら探索を終了
-			}
-			return nil
-		})
-		if err != nil {
-			return false
-		}
-		return found
+		return fileExistsRecursive(condition.Value)
 	}
 	return false
 }
@@ -121,10 +107,7 @@ func checkPostToolUseCondition(condition PostToolUseCondition, input *PostToolUs
 		}
 	case "file_exists":
 		// 指定ファイルが存在する
-		if condition.Value != "" {
-			_, err := os.Stat(condition.Value)
-			return err == nil
-		}
+		return fileExists(condition.Value)
 	case "url_starts_with":
 		// URLが指定文字列で始まる
 		if input.ToolInput.URL != "" {


### PR DESCRIPTION
## 概要

SessionStartイベントに条件チェック機能を追加し、プロジェクトタイプに応じた初期化メッセージを表示できるようにしました。

## 修正が必要になった背景

SessionStartイベントでは、これまでmatcherによるフィルタリング（startup/resume/clear）のみ対応していましたが、条件に基づいたフィルタリングができませんでした。そのため、`go.mod`の有無に関わらずGolang用のメッセージが表示され、`pyproject.toml`の有無に関わらずPython用のメッセージが表示されるという問題がありました。

## 変更内容

### 機能追加
- SessionStartHook構造体に`Conditions`フィールドを追加
- SessionStartCondition型を新規作成
- checkSessionStartCondition関数を追加（`file_exists`と`file_exists_recursive`をサポート）
- executeSessionStartHooksとdryRunSessionStartHooksに条件チェックロジックを追加

### リファクタリング
- `file_exists`と`file_exists_recursive`の処理を共通関数として抽出
  - `fileExists(path string) bool`
  - `fileExistsRecursive(filename string) bool`
- 4箇所の条件チェック関数（PreToolUse、PostToolUse、SessionStart、UserPromptSubmit）で共通関数を使用

### テスト
- SessionStart条件チェック機能のテストケースを追加
- 既存のテストも全てパス

### ドキュメント
- README.mdにSessionStartの条件サポートについて記載
- 設定例を追加

## 動作確認

```yaml
SessionStart:
  - matcher: "startup"
    conditions:
      - type: file_exists
        value: "go.mod"
    actions:
      - type: output
        message: "Golangのファイルを検索や修正する際は、serena mcpを活用しましょう"
  - matcher: "startup"
    conditions:
      - type: file_exists_recursive
        value: "pyproject.toml"
    actions:
      - type: output
        message: "Pythonのファイルを検索や修正する際は、serena mcpを活用しましょう"
```

上記の設定により：
- Golangプロジェクト（`go.mod`が存在）: Golang用のメッセージのみ表示
- Pythonプロジェクト（`pyproject.toml`が存在）: Python用のメッセージのみ表示
- どちらも存在しない場合: どちらのメッセージも表示されない
