### PR TITLE
fix: add missing every_n_prompts case in YAML unmarshaling

### DIFF
--- a/types.go
+++ b/types.go
@@ -252,6 +252,8 @@ func (c *ConditionType) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		*c = ConditionURLStartsWith
 	case "prompt_regex":
 		*c = ConditionPromptRegex
+	case "every_n_prompts":
+		*c = ConditionEveryNPrompts
 	case "git_tracked_file_operation":
 		*c = ConditionGitTrackedFileOperation
 	default:


### PR DESCRIPTION
## 概要

`every_n_prompts` 条件タイプがYAML設定ファイルから正しく読み込めない問題を修正しました。

## 背景

`every_n_prompts` という条件タイプは `types.go` で定義されていましたが、`ConditionType.UnmarshalYAML` メソッド内でこの条件タイプを処理するケースが欠落していました。

このため、設定ファイルで `every_n_prompts` を使用すると以下のエラーが発生していました：
```
Error loading config: failed to parse config file: invalid condition type: every_n_prompts
```

## 修正内容

- `types.go` の `UnmarshalYAML` メソッドに `every_n_prompts` のケースを追加
- これにより、YAML設定ファイルから `every_n_prompts` 条件タイプが正しくパースされるようになりました

## テスト

既存のテストケース `TestCheckUserPromptSubmitCondition` には `every_n_prompts` のテストが含まれており、すべてのテストが成功することを確認しました。

```bash
go test -v -run TestCheckUserPromptSubmitCondition ./...
# 全21件のテストケースが成功
```

## 影響範囲

- 設定ファイルの読み込み処理のみに影響
- 既存の機能への影響なし
- 後方互換性を維持
